### PR TITLE
Fix detection of scorers

### DIFF
--- a/csv_reconcile/__init__.py
+++ b/csv_reconcile/__init__.py
@@ -147,7 +147,7 @@ def create_app(setup=None, config=None, instance_path=None):
 
 
 def pickScorer(plugin):
-    eps = metadata.entry_points()['csv_reconcile.scorers']
+    eps = metadata.entry_points().get('csv_reconcile.scorers', [])
     if len(eps) == 0:
         raise RuntimeError("Please install a \"csv_reconcile.scorers\" plugin")
     elif plugin:


### PR DESCRIPTION
When I tried to install the project with Python 3.7, two small issues popped up:
* ~`importlib.resources` is only available in Python >=3.9. However, there is a [backport](https://github.com/python/importlib_resources) which fallsback to the standard library on newer versions.~
* `metadata.entry_points()` might not return a key named `csv_reconcile.scorers` at all