### PR TITLE
Return column label in data extension responses

### DIFF
--- a/tests/test_csv_reconcile.py
+++ b/tests/test_csv_reconcile.py
@@ -57,13 +57,11 @@ def test_data_extension_basics(basicClient, setup, header, typicalrow,
     assert type(cols['properties']) == list  # [ {id:..., name:...}, ... ]
 
     # Every thing but id and name col available for extension
-    availableCols = {}
+    availableCols = []
     for itm in cols['properties']:
-
-        # internal and external column name
         assert set(itm.keys()) == set(('id', 'name'))
 
-        availableCols[itm['id']] = itm['name']
+        availableCols.append(itm['id'])
 
     assert set(availableCols) == set(header)
 
@@ -83,12 +81,12 @@ def test_data_extension_basics(basicClient, setup, header, typicalrow,
     assert colid in extenddata['rows']
 
     row = extenddata['rows'][colid]
-    for colextra, colextra_dbnm in availableCols.items():
+    for colextra in availableCols:
         exidx = header.index(colextra)
 
-        assert colextra_dbnm in row
+        assert colextra in row
 
-        for choice in row[colextra_dbnm]:
+        for choice in row[colextra]:
             assert 'str' in choice
             assert choice['str'] == typicalrow[exidx]
 


### PR DESCRIPTION
According to [the specs](https://reconciliation-api.github.io/specs/0.1/), data extension responses should include a key named `name` for all properties in `meta`. If not set, OpenRefine sets all column labels to *null*. To fix this issue, I set `id` and `name` to the not-normalized column name. The normalized name is only used for the database queries. 

![example](https://user-images.githubusercontent.com/20755228/115406376-66ddce00-a1ef-11eb-8344-0d1c3821ec1b.png)
