### PR TITLE
Use first line of CSV to detect dialect

### DIFF
--- a/csv_reconcile/initdb.py
+++ b/csv_reconcile/initdb.py
@@ -75,7 +75,7 @@ def init_db(db,
         with open(csvfilenm, newline='', **enckwarg) as csvfile:
             dialect = None
             try:
-                dialect = csv.Sniffer().sniff(csvfile.read(1024))
+                dialect = csv.Sniffer().sniff(csvfile.readline())
             except:
                 pass
 


### PR DESCRIPTION
Fixes errors where CSV sniffer fails to detect CSV dialect with only a fixed amount of data.  Normally a problem for files with longer column titles.

Fixes #119 